### PR TITLE
Make it possible to configure the allowed HTTP methods.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@ distribution under the MIT license in LICENSE.md:
 
 * Owen Jacobson <owen@grimoire.ca>
 * Victor Elci <veelci@gmail.com>
+* Ewan Mellor <commits@ewanmellor.org>

--- a/src/test/java/ca/grimoire/dropwizard/cors/config/CrossOriginFilterFactoryTest.java
+++ b/src/test/java/ca/grimoire/dropwizard/cors/config/CrossOriginFilterFactoryTest.java
@@ -9,8 +9,11 @@ import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 import java.util.EnumSet;
 
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class CrossOriginFilterFactoryTest {
@@ -34,6 +37,7 @@ public class CrossOriginFilterFactoryTest {
         verify(servlets).addFilter("CrossOriginFilter", CrossOriginFilter.class);
         verify(filter).setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "http://unit.example.com");
         verify(filter).setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, "Authorization,X-Requested-With,Content-Type,Accept,Origin,Cache-Control");
+        verify(filter, never()).setInitParameter(eq(CrossOriginFilter.ALLOWED_METHODS_PARAM), anyString());
         verify(filter).addMappingForUrlPatterns(
                 EnumSet.of(DispatcherType.REQUEST),
                 false,
@@ -48,11 +52,21 @@ public class CrossOriginFilterFactoryTest {
         verify(servlets).addFilter("CrossOriginFilter", CrossOriginFilter.class);
         verify(filter).setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "http://localhost:*");
         verify(filter).setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, "Authorization,X-Requested-With,Content-Type,Accept,Origin");
+        verify(filter, never()).setInitParameter(eq(CrossOriginFilter.ALLOWED_METHODS_PARAM), anyString());
         verify(filter).addMappingForUrlPatterns(
                 EnumSet.of(DispatcherType.REQUEST),
                 false,
                 "*"
         );
+    }
+
+    @Test
+    public void registersFilterWithMethods() {
+        factory.setAllowedMethods("GET,HEAD,PATCH,POST");
+        factory.registerFilter(servlets);
+
+        verify(servlets).addFilter("CrossOriginFilter", CrossOriginFilter.class);
+        verify(filter).setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, "GET,HEAD,PATCH,POST");
     }
 
 }


### PR DESCRIPTION
Add CrossOriginFilterFactory.setAllowedMethods.  Pass this through
to CrossOriginFilter.ALLOWED_METHODS_PARAM if set.  If this is not
set, the behavior does not change (we use Jetty's default setting).