### PR TITLE
make sure license is written to pom file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ distribution under the MIT license in LICENSE.md:
 * Owen Jacobson <owen@grimoire.ca>
 * Victor Elci <veelci@gmail.com>
 * Ewan Mellor <commits@ewanmellor.org>
+* Josef H.B. Schneider <git@netpage.dk>

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,16 @@ apply plugin: 'com.jfrog.bintray'
 group = 'ca.grimoire.dropwizard.cors'
 sourceCompatibility = '1.8'
 
+def pomConfig = {
+	licenses {
+		license([:]) {
+			name "MIT License"
+			url "http://opensource.org/licenses/MIT"
+			distribution "repo"
+		}
+	}
+}
+
 release {
     grgit = Grgit.open(projectDir)
 }
@@ -71,6 +81,15 @@ publishing {
 
             artifact sourcesJar
             artifact javadocJar
+			groupId 'ca.grimoire.dropwizard.cors'
+            artifactId 'dropwizard-simple-cors'
+            version = project.version
+			pom.withXml {
+                def root = asNode()
+                root.appendNode('name', 'Dropwizard Simple CORS')
+                root.appendNode('url', 'https://github.com/ojacobson/dropwizard-simple-cors')
+                root.children().last() + pomConfig
+            }
         }
     }
 }


### PR DESCRIPTION
We use a automated tool to validate that the licenses of all dependencies are compatible with out own licenses.

dropwizard-simple-cors currently has no license in the pom file, so it needs manual exceptions.

With this changes, the license information is written to the pom.xml file.