### PR TITLE
Fix test warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrestVersion
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: hamcrestVersion
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.18.3'
 }
 
 


### PR DESCRIPTION
Mockito is updated to a Version compatible with Java 9
This fixes Issue #12
